### PR TITLE
Exclude tests in find_packages

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+0.1.2 (YYYY-MM-DD)
+------------------
+
+* Exclude "tests" package from the installation.
+
 0.1.1 (2019-11-13)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='Matthew Westcott',
     author_email='matthew.westcott@torchbox.com',
     url='https://github.com/gasman/wagtail-generic-chooser',
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests", "tests.*")),
     include_package_data=True,
     install_requires=[
         'requests>=2.11.1,<3.0',


### PR DESCRIPTION
The problem is `tests` package gets installed.

This PR makes sure that it's excluded from a wheel and source distribution.