### PR TITLE
Add 'linked field' mechanism

### DIFF
--- a/generic_chooser/static/generic_chooser/js/chooser-widget-telepath.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget-telepath.js
@@ -6,7 +6,7 @@
         var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
         placeholder.outerHTML = html;
 
-        var chooser = createChooserWidget(id);
+        var chooser = new ChooserWidget(id);
         chooser.setState(initialState);
         return chooser;
     };

--- a/generic_chooser/static/generic_chooser/js/chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget.js
@@ -9,6 +9,7 @@ function ChooserWidget(id, opts) {
     opts = opts || {};
     var self = this;
 
+    this.id = id;
     this.chooserElement = $('#' + id + '-chooser');
     this.titleElement = this.chooserElement.find('.title');
     this.inputElement = $('#' + id);

--- a/generic_chooser/static/generic_chooser/js/chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget.js
@@ -1,4 +1,4 @@
-function createChooserWidget(id, opts) {
+function ChooserWidget(id, opts) {
     /*
     id = the ID of the HTML element where chooser behaviour should be attached
     opts = dictionary of configuration options, which may include:
@@ -7,70 +7,78 @@ function createChooserWidget(id, opts) {
     */
 
     opts = opts || {};
+    var self = this;
 
-    var chooserElement = $('#' + id + '-chooser');
-    var docTitle = chooserElement.find('.title');
-    var input = $('#' + id);
-    var editLink = chooserElement.find('.edit-link');
-    var editLinkWrapper = chooserElement.find('.edit-link-wrapper');
-    if (!editLink.attr('href')) {
-        editLinkWrapper.hide();
+    this.chooserElement = $('#' + id + '-chooser');
+    this.titleElement = this.chooserElement.find('.title');
+    this.inputElement = $('#' + id);
+    this.editLinkElement = this.chooserElement.find('.edit-link');
+    this.editLinkWrapper = this.chooserElement.find('.edit-link-wrapper');
+    if (!this.editLinkElement.attr('href')) {
+        this.editLinkWrapper.hide();
     }
-    var chooseButton = $('.action-choose', chooserElement);
+    this.chooseButton = $('.action-choose', this.chooserElement);
+    this.idForLabel = null;
 
-    var widget = {
-        idForLabel: null,
-        getState: function() {
-            return {
-                'value': input.val(),
-                'title': docTitle.text(),
-                'edit_item_url': editLink.attr('href')
-            };
-        },
-        getValue: function() {
-            return input.val();
-        },
-        setState: function(newState) {
-            if (newState && newState.value !== null && newState.value !== '') {
-                input.val(newState.value);
-                docTitle.text(newState.title);
-                chooserElement.removeClass('blank');
-                if (newState.edit_item_url) {
-                    editLink.attr('href', newState.edit_item_url);
-                    editLinkWrapper.show();
-                } else {
-                    editLinkWrapper.hide();
-                }
-            } else {
-                input.val('');
-                chooserElement.addClass('blank');
-            }
-        },
-        focus: function() {
-            chooseButton.focus();
-        }
+    this.modalResponses = {};
+    this.modalResponses[opts.modalWorkflowResponseName || 'chosen'] = function(data) {
+        self.setState({
+            'value': data.id,
+            'title': data.string,
+            'edit_item_url': data.edit_link
+        });
     };
 
-    chooseButton.on('click', function() {
-        var responses = {};
-        responses[opts.modalWorkflowResponseName || 'chosen'] = function(snippetData) {
-            widget.setState({
-                'value': snippetData.id,
-                'title': snippetData.string,
-                'edit_item_url': snippetData.edit_link
-            });
-        };
-
-        ModalWorkflow({
-            url: chooserElement.data('choose-modal-url'),
-            onload: GENERIC_CHOOSER_MODAL_ONLOAD_HANDLERS,
-            responses: responses
-        });
+    this.chooseButton.on('click', function() {
+        self.openModal();
     });
 
-    $('.action-clear', chooserElement).on('click', function() {
-        widget.setState(null);
+    $('.action-clear', this.chooserElement).on('click', function() {
+        self.setState(null);
     });
+}
 
-    return widget;
+ChooserWidget.prototype.getModalURL = function() {
+    return this.chooserElement.data('choose-modal-url');
+};
+
+ChooserWidget.prototype.openModal = function() {
+    ModalWorkflow({
+        url: this.getModalURL(),
+        onload: GENERIC_CHOOSER_MODAL_ONLOAD_HANDLERS,
+        responses: this.modalResponses
+    });
+};
+
+ChooserWidget.prototype.setState = function(newState) {
+    if (newState && newState.value !== null && newState.value !== '') {
+        this.inputElement.val(newState.value);
+        this.titleElement.text(newState.title);
+        this.chooserElement.removeClass('blank');
+        if (newState.edit_item_url) {
+            this.editLinkElement.attr('href', newState.edit_item_url);
+            this.editLinkWrapper.show();
+        } else {
+            this.editLinkWrapper.hide();
+        }
+    } else {
+        this.inputElement.val('');
+        this.chooserElement.addClass('blank');
+    }
+};
+
+ChooserWidget.prototype.getState = function() {
+    return {
+        'value': this.inputElement.val(),
+        'title': this.titleElement.text(),
+        'edit_item_url': this.editLinkElement.attr('href')
+    };
+};
+
+ChooserWidget.prototype.getValue = function() {
+    return this.inputElement.val();
+};
+
+ChooserWidget.prototype.focus = function() {
+    this.chooseButton.focus();
 }

--- a/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget-telepath.js
+++ b/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget-telepath.js
@@ -1,0 +1,16 @@
+(function() {
+    function LinkedFieldChooser(html, opts) {
+        this.html = html;
+        this.opts = opts;
+    }
+    LinkedFieldChooser.prototype.render = function(placeholder, name, id, initialState) {
+        var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
+        placeholder.outerHTML = html;
+
+        var chooser = new LinkedFieldChooserWidget(id, this.opts);
+        chooser.setState(initialState);
+        return chooser;
+    };
+
+    window.telepath.register('wagtail_generic_chooser.widgets.LinkedFieldChooser', LinkedFieldChooser);
+})();

--- a/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget.js
@@ -1,0 +1,33 @@
+function LinkedFieldChooserWidget(id, opts) {
+    /* A ChooserWidget which can pull values from other form elements to pass
+    to the chooser modal as extra URL parameters. Define these by passing
+    a 'linkedFields' dictionary in opts, of the form:
+        {'urlParamName': '#some-css-selector'}
+    which means: when generating the modal URL, look up the element matching
+    some-css-selector, get its value, and add that to the URL as the
+    parameter urlParamName.
+    */
+    opts = opts || {};
+    ChooserWidget.call(this, id, opts);
+
+    this.linkedFields = opts.linkedFields || {};
+}
+
+LinkedFieldChooserWidget.prototype = Object.create(ChooserWidget.prototype);
+
+LinkedFieldChooserWidget.prototype.getModalURL = function() {
+    var url = ChooserWidget.prototype.getModalURL.call(this);
+
+    queryParams = [];
+    for (var param in this.linkedFields) {
+        var selector = this.linkedFields[param];
+        var val = $(document).find(selector).val();
+        queryParams.push({'name': param, 'value': val});
+    }
+    if (url.indexOf('?') == -1) {
+        url += '?' + $.param(queryParams);
+    } else {
+        url += '&' + $.param(queryParams);
+    }
+    return url;
+}

--- a/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget.js
@@ -2,10 +2,17 @@ function LinkedFieldChooserWidget(id, opts) {
     /* A ChooserWidget which can pull values from other form elements to pass
     to the chooser modal as extra URL parameters. Define these by passing
     a 'linkedFields' dictionary in opts, of the form:
-        {'urlParamName': '#some-css-selector'}
-    which means: when generating the modal URL, look up the element matching
-    some-css-selector, get its value, and add that to the URL as the
+        {'urlParamName': {'id': 'some-element-id'}}
+    which means: when generating the modal URL, look up the element with
+    id="some-element-id", get its value, and add that to the URL as the
     parameter urlParamName.
+
+    Alternative lookup types:
+        {'urlParamName': {'selector': '.some-selector'}}
+        - look up the element matching the given CSS selector
+        {'urlParamName': {'match': r'^body-\d+-value-', 'append': 'country'}}
+        - look up the ID formed by matching the CURRENT widget's ID against
+          the given regexp, then appending the given string
     */
     opts = opts || {};
     ChooserWidget.call(this, id, opts);
@@ -20,9 +27,27 @@ LinkedFieldChooserWidget.prototype.getModalURL = function() {
 
     queryParams = [];
     for (var param in this.linkedFields) {
-        var selector = this.linkedFields[param];
-        var val = $(document).find(selector).val();
-        queryParams.push({'name': param, 'value': val});
+        var lookup = this.linkedFields[param];
+        var val;
+        if (typeof(lookup) == 'string') {
+            val = $(document).find(lookup).val();
+        } else if (lookup.id) {
+            val = $(document).find('#' + lookup.id).val();
+        } else if (lookup.selector) {
+            val = $(document).find(lookup.selector).val();
+        } else if (lookup.match) {
+            var match = this.id.match(new RegExp(lookup.match));
+            if (match) {
+                var id = match[0];
+                if (lookup.append) {
+                    id += lookup.append;
+                }
+                val = $(document).find('#' + id).val();
+            }
+        }
+        if (val) {
+            queryParams.push({'name': param, 'value': val});
+        }
     }
     if (url.indexOf('?') == -1) {
         url += '?' + $.param(queryParams);

--- a/generic_chooser/widgets.py
+++ b/generic_chooser/widgets.py
@@ -151,7 +151,7 @@ class AdminChooser(WidgetWithScript, widgets.Input):
         })
 
     def render_js_init(self, id_, name, value):
-        return "createChooserWidget({0});".format(json.dumps(id_))
+        return "new ChooserWidget({0});".format(json.dumps(id_))
 
     def __init__(self, **kwargs):
         # allow choose_one_text / choose_another_text to be overridden per-instance

--- a/generic_chooser/widgets.py
+++ b/generic_chooser/widgets.py
@@ -228,8 +228,11 @@ class LinkedFieldMixin:
         self.linked_fields = kwargs.pop('linked_fields', {})
         super().__init__(*args, **kwargs)
 
+    def js_opts(self):
+        return {'linkedFields': self.linked_fields}
+
     def render_js_init(self, id_, name, value):
-        opts = {'linkedFields': self.linked_fields}
+        opts = self.js_opts()
         return "new LinkedFieldChooserWidget({0}, {1});".format(json.dumps(id_), json.dumps(opts))
 
     @property
@@ -238,3 +241,23 @@ class LinkedFieldMixin:
             'generic_chooser/js/chooser-widget.js',
             'generic_chooser/js/linked-field-chooser-widget.js',
         ])
+
+
+class LinkedFieldChooserAdapter(WidgetAdapter):
+    js_constructor = 'wagtail_generic_chooser.widgets.LinkedFieldChooser'
+
+    def js_args(self, widget):
+        return [
+            widget.render_html(
+                "__NAME__", widget.get_value_data(None), attrs={"id": "__ID__"}
+            ),
+            widget.js_opts(),
+        ]
+
+    class Media:
+        js = [
+            "generic_chooser/js/linked-field-chooser-widget-telepath.js",
+        ]
+
+
+register(LinkedFieldChooserAdapter(), LinkedFieldMixin)


### PR DESCRIPTION
Implement a mechanism for pulling arbitrary form field values from the calling page and passing them to the chooser modal as URL parameters for additional filtering. Example code:

    from generic_chooser.widgets import AdminChooser, LinkedFieldMixin
    from generic_chooser.views import ModelChooserMixin, ModelChooserViewSet

    # define a chooser widget that accepts a `linked_fields` kwarg
    class PersonChooser(LinkedFieldMixin, AdminChooser):
        model = Person


    # define a chooser modal for Person that accepts a `country` URL parameter to filter on
    class PersonChooserMixin(ModelChooserMixin):
        preserve_url_parameters = ['country',]  # preserve this URL parameter on pagination / search

        def get_unfiltered_object_list(self):
            objects = super().get_unfiltered_object_list()
            country = self.request.GET.get('country')
            if country:
                objects = objects.filter(country_id=country)
            return objects


    class PersonChooserViewSet(ModelChooserViewSet):
        model = Person
        chooser_mixin_class = PersonChooserMixin


    # use this chooser on a BlogPage with a country field, to only show authors from the selected country
    class BlogPage(Page):
        country = models.ForeignKey(Country)
        author = models.ForeignKey(Person)

        content_panels = Page.content_panels + [
            FieldPanel('country')
            FieldPanel('person', widget=PersonChooser(linked_fields={
                'country': '#id_country',  # pass the chosen country to the person chooser as a URL parameter `country`
            }))
        ]
