### PR TITLE
Add the ability to add a create item link

### DIFF
--- a/generic_chooser/templates/generic_chooser/widgets/chooser.html
+++ b/generic_chooser/templates/generic_chooser/widgets/chooser.html
@@ -21,11 +21,17 @@
             {% if widget.show_edit_link and edit_item_url %}
                 <li><a href="{{ edit_item_url }}" class="edit-link button button-small button-secondary" target="_blank" rel="noopener noreferrer">{{ widget.link_to_chosen_text }}</a></li>
             {% endif %}
+            {% if widget.show_create_link and create_item_url %}
+                <li><a href="{{ create_item_url }}" class="create-link button button-small button-secondary" target="_blank" rel="noopener noreferrer">{{ widget.link_to_create_text }}</a></li>
+            {% endif %}
         </ul>
     </div>
 
     <div class="unchosen">
         <button type="button" class="button action-choose button-small button-secondary">{{ widget.choose_one_text }}</button>
+        {% if widget.show_create_link and create_item_url %}
+            <a href="{{ create_item_url }}" class="edit-link button button-small button-secondary" target="_blank" rel="noopener noreferrer">{{ widget.link_to_create_text }}</a>
+        {% endif %}
     </div>
 
 </div>

--- a/generic_chooser/widgets.py
+++ b/generic_chooser/widgets.py
@@ -18,10 +18,17 @@ class AdminChooser(WidgetWithScript, widgets.Input):
     choose_another_text = _("Choose another item")
     clear_choice_text = _("Clear choice")
     link_to_chosen_text = _("Edit this item")
+    link_to_create_text = _("Create an item")
     show_edit_link = True
+    show_create_link = True
+
     classname = None  # CSS class for the top-level element
 
     model = None
+
+    # URL route name for creating a new item - should return the URL of the item's create view.
+    # If no suitable URL route exists (e.g. it requires additional arguments), subclasses can override get_create_item_url instead.
+    create_item_url_name = None
 
     # URL route name for editing an existing item - should return the URL of the item's edit view
     # when reversed with the item's quoted PK as its only argument. If no suitable URL route exists
@@ -44,6 +51,12 @@ class AdminChooser(WidgetWithScript, widgets.Input):
     def get_instance(self, value):
         return self.model.objects.get(pk=value)
 
+    def get_create_item_url(self):
+        if self.create_item_url_name is None:
+            return None
+        else:
+            return reverse(self.create_item_url_name)
+    
     def get_edit_item_url(self, instance):
         if self.edit_item_url_name is None:
             return None
@@ -91,6 +104,7 @@ class AdminChooser(WidgetWithScript, widgets.Input):
             'value': value,
             'item': instance,
             'title': '' if instance is None else self.get_title(instance),
+            'create_item_url': self.get_create_item_url(),
             'edit_item_url': edit_item_url,
             'choose_modal_url': self.get_choose_modal_url(),
         })


### PR DESCRIPTION
This builds upon the "edit item" logic to add the ability to link to a create page on the chooser widget.
This is useful in scenarios where you aren't able to use the create tab to create a model (because of the need for an image chooser)