### PR TITLE
Fix typo in var name: request -> searchRequest

### DIFF
--- a/generic_chooser/static/generic_chooser/js/chooser-modal.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-modal.js
@@ -39,7 +39,7 @@ GENERIC_CHOOSER_MODAL_ONLOAD_HANDLERS = {
 
         $('#id_q').on('input', function() {
             if(searchRequest) {
-                request.abort();
+                searchRequest.abort();
             }
             clearTimeout($.data(this, 'timer'));
             var wait = setTimeout(search, 50);


### PR DESCRIPTION
When I enabled the search input in a chooser dialog I get these javascript errors:

<img width="874" alt="search-error" src="https://user-images.githubusercontent.com/121401/116986992-ca2b2e00-acce-11eb-95cb-e3e24cef3185.png">

This is because the `.abort()` method is called on the variable `request` which should be `searchRequest`. This PR fixes this.