### PR TITLE
Consistently handle empty states from telepath / getState / setState

### DIFF
--- a/generic_chooser/static/generic_chooser/js/chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget.js
@@ -31,7 +31,7 @@ function createChooserWidget(id, opts) {
             return input.val();
         },
         setState: function(newState) {
-            if (newState) {
+            if (newState && newState.value !== null && newState.value !== '') {
                 input.val(newState.value);
                 docTitle.text(newState.title);
                 chooserElement.removeClass('blank');


### PR DESCRIPTION
setState needs to handle a dict with a blank 'value' field as an empty state, as that's what get_value_data returns for use in the telepath adapter, and what getState (used for block duplication) returns.

Without this, a newly-added block shows the buttons from the 'chosen' state:
![Screenshot 2021-07-22 at 18 09 20](https://user-images.githubusercontent.com/85097/126681068-f099dbaa-ff02-4cf1-887b-c5a5b434b495.png)
