### PR TITLE
Replace deprecated url import

### DIFF
--- a/generic_chooser/views.py
+++ b/generic_chooser/views.py
@@ -1,7 +1,7 @@
 import requests
 import urllib
 
-from django.conf.urls import url
+import django
 from django.contrib.admin.utils import quote, unquote
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.core.paginator import Page, Paginator
@@ -20,6 +20,11 @@ from wagtail.admin.viewsets.base import ViewSet
 from wagtail.core.permission_policies import ModelPermissionPolicy
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
+
+if django.VERSION >= (3, 1):
+    from django.urls import re_path
+else:
+    from django.conf.urls import url as re_path
 
 
 class ModalPageFurnitureMixin(ContextMixin):
@@ -651,8 +656,8 @@ class ChooserViewSet(ViewSet):
 
     def get_urlpatterns(self):
         return super().get_urlpatterns() + [
-            url(r'^$', self.choose_view, name='choose'),
-            url(r'^(\d+)/$', self.chosen_view, name='chosen'),
+            re_path(r'^$', self.choose_view, name='choose'),
+            re_path(r'^(\d+)/$', self.chosen_view, name='chosen'),
         ]
 
 

--- a/generic_chooser/views.py
+++ b/generic_chooser/views.py
@@ -1,14 +1,13 @@
 import requests
 import urllib
 
-import django
 from django.contrib.admin.utils import quote, unquote
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.core.paginator import Page, Paginator
 from django.forms import models as model_forms
 from django.http import Http404
 from django.shortcuts import render
-from django.urls import reverse
+from django.urls import re_path, reverse
 from django.utils.text import camel_case_to_spaces, slugify
 from django.utils.translation import gettext_lazy as _
 from django.views import View
@@ -20,11 +19,6 @@ from wagtail.admin.viewsets.base import ViewSet
 from wagtail.core.permission_policies import ModelPermissionPolicy
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
-
-if django.VERSION >= (3, 1):
-    from django.urls import re_path
-else:
-    from django.conf.urls import url as re_path
 
 
 class ModalPageFurnitureMixin(ContextMixin):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,16 +1,10 @@
-import django
-from django.conf.urls import include
+from django.conf.urls import include, re_path
 from rest_framework import routers, serializers, viewsets
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 
 from .api import api_router as wagtail_api_router
 from .models import Person
-
-if django.VERSION >= (3, 1):
-    from django.urls import re_path
-else:
-    from django.conf.urls import url as re_path
 
 
 class PersonSerializer(serializers.HyperlinkedModelSerializer):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import include
-from django.urls import re_path
+from django.urls import path
 from rest_framework import routers, serializers, viewsets
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
@@ -24,11 +24,11 @@ router = routers.DefaultRouter()
 router.register(r'person-api', PersonViewSet)
 
 urlpatterns = [
-    re_path(r'^admin/', include(wagtailadmin_urls)),
-    re_path(r'^api/v2/', wagtail_api_router.urls),
+    path('admin/', include(wagtailadmin_urls)),
+    path('api/v2/', wagtail_api_router.urls),
 
     # Wire up our API using automatic URL routing.
-    re_path(r'^', include(router.urls)),
+    path('', include(router.urls)),
 
-    re_path(r'', include(wagtail_urls)),
+    path('', include(wagtail_urls)),
 ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,16 @@
-from django.conf.urls import include, url
+import django
+from django.conf.urls import include
 from rest_framework import routers, serializers, viewsets
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 
 from .api import api_router as wagtail_api_router
 from .models import Person
+
+if django.VERSION >= (3, 1):
+    from django.urls import re_path
+else:
+    from django.conf.urls import url as re_path
 
 
 class PersonSerializer(serializers.HyperlinkedModelSerializer):
@@ -23,11 +29,11 @@ router = routers.DefaultRouter()
 router.register(r'person-api', PersonViewSet)
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'^api/v2/', wagtail_api_router.urls),
+    re_path(r'^admin/', include(wagtailadmin_urls)),
+    re_path(r'^api/v2/', wagtail_api_router.urls),
 
     # Wire up our API using automatic URL routing.
-    url(r'^', include(router.urls)),
+    re_path(r'^', include(router.urls)),
 
-    url(r'', include(wagtail_urls)),
+    re_path(r'', include(wagtail_urls)),
 ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import include, re_path
+from django.conf.urls import include
+from django.urls import re_path
 from rest_framework import routers, serializers, viewsets
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls


### PR DESCRIPTION
The django.conf.urls.url() alias of django.urls.re_path() is
deprecated as of Django 3.1 and will be removed in 4.0 (which is
currently in alpha).

This commit changes the import to use the orignal alias for versions
before 3.1 and uses django.urls.re_path directly for newer versions.

See also:
https://docs.djangoproject.com/en/3.2/releases/3.1/#id2

Closes #41