### PR TITLE
Disable the "create" button after it is clicked to prevent duplication

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ Unreleased
 ----------------
 
 * Wagtail 4.0 support (Katherine Domingo)
-
+* Prevent duplicate create calls against slow APIs
 
 0.4.1 (2022-07-07)
 ------------------

--- a/generic_chooser/static/generic_chooser/js/chooser-modal.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-modal.js
@@ -68,6 +68,9 @@ GENERIC_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         }
 
         $('form.create-form', modal.body).on('submit', function() {
+            const button = $(this).find('[type="submit"]');
+            button.prop("disabled", true);
+
             var formdata = new FormData(this);
 
             $.ajax({


### PR DESCRIPTION
When the create form is used, it's possible to create several duplicate instances of a model (or, generically, make several calls to the create endpoint) while the modal is waiting for a response. Disabling this button in the event handler prevents the button from being repeatedly clicked.

Similar issue to #25 , but on the create side