### PR TITLE
Populate widget title element correctly on Wagtail 4

### DIFF
--- a/generic_chooser/static/generic_chooser/js/chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget.js
@@ -11,7 +11,7 @@ function ChooserWidget(id, opts) {
 
     this.id = id;
     this.chooserElement = $('#' + id + '-chooser');
-    this.titleElement = this.chooserElement.find('.title');
+    this.titleElement = this.chooserElement.find('[data-chooser-title]');
     this.inputElement = $('#' + id);
     this.editLinkElement = this.chooserElement.find('.edit-link');
     this.editLinkWrapper = this.chooserElement.find('.edit-link-wrapper');

--- a/generic_chooser/templates/generic_chooser/widgets/chooser.html
+++ b/generic_chooser/templates/generic_chooser/widgets/chooser.html
@@ -10,7 +10,7 @@
 
     <div class="chosen">
         {% block chosen_state_view %}
-            <span class="title">{{ title }}</span>
+            <span class="title" data-chooser-title>{{ title }}</span>
         {% endblock %}
 
         <ul class="actions">

--- a/generic_chooser/templates/generic_chooser/widgets/chooser_v4.html
+++ b/generic_chooser/templates/generic_chooser/widgets/chooser_v4.html
@@ -17,7 +17,7 @@
             </div>
         {% endblock chosen_icon %}
         {% block chosen_state_view %}
-            <div class="chooser__title">{{ title }}</div>
+            <div class="chooser__title" data-chooser-title>{{ title }}</div>
         {% endblock %}
 
         <ul class="chooser__actions">

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -603,6 +603,6 @@ class TestChooserWidget(TestCase):
         form = SiteForm(initial={'site': localhost})
         html = form.as_p()
         if WAGTAIL_VERSION >= (4, 0):
-            self.assertIn('<div class="chooser__title">localhost [default]</div>', html)
+            self.assertIn('<div class="chooser__title" data-chooser-title>localhost [default]</div>', html)
         else:
-            self.assertIn('<span class="title">localhost [default]</span>', html)
+            self.assertIn('<span class="title" data-chooser-title>localhost [default]</span>', html)


### PR DESCRIPTION
The v4 chooser template changed the title element from `<span class="title">` to `<div class="chooser__title">`, but the JS was still targetting the `title` class. Add a `data-chooser-title` attribute so that the JS behaviour is decoupled from the CSS-oriented class names.