### PR TITLE
Add multiple choice UI and new factory methods

### DIFF
--- a/generic_chooser/static/generic_chooser/js/chooser-modal.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-modal.js
@@ -91,6 +91,8 @@ GENERIC_CHOOSER_MODAL_ONLOAD_HANDLERS = {
 
             return false;
         });
+
+        modal.ajaxifyForm('form[data-multiple-choice-form]');
     },
     'chosen': function(modal, jsonData) {
         modal.respond('chosen', jsonData['result']);

--- a/generic_chooser/static/generic_chooser/js/chooser-widget-telepath.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget-telepath.js
@@ -1,15 +1,3 @@
 (function() {
-    function Chooser(html) {
-        this.html = html;
-    }
-    Chooser.prototype.render = function(placeholder, name, id, initialState) {
-        var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
-        placeholder.outerHTML = html;
-
-        var chooser = new ChooserWidget(id);
-        chooser.setState(initialState);
-        return chooser;
-    };
-
-    window.telepath.register('wagtail_generic_chooser.widgets.Chooser', Chooser);
+    window.telepath.register('wagtail_generic_chooser.widgets.Chooser', window.WagtailGenericChooserWidgetFactory);
 })();

--- a/generic_chooser/static/generic_chooser/js/chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget.js
@@ -84,3 +84,17 @@ ChooserWidget.prototype.getValue = function() {
 ChooserWidget.prototype.focus = function() {
     this.chooseButton.focus();
 }
+
+
+function ChooserWidgetFactory(html) {
+    this.html = html;
+}
+ChooserWidgetFactory.prototype.render = function(placeholder, name, id, initialState) {
+    var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
+    placeholder.outerHTML = html;
+
+    var chooser = new ChooserWidget(id);
+    chooser.setState(initialState);
+    return chooser;
+};
+window.WagtailGenericChooserWidgetFactory = ChooserWidgetFactory;

--- a/generic_chooser/static/generic_chooser/js/chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget.js
@@ -20,6 +20,7 @@ function ChooserWidget(id, opts) {
     }
     this.chooseButton = $('.action-choose', this.chooserElement);
     this.idForLabel = null;
+    this.baseModalURL = opts.modalURL || this.chooserElement.data('choose-modal-url');
 
     this.modalResponses = {};
     this.modalResponses[opts.modalWorkflowResponseName || 'chosen'] = function(data) {
@@ -41,7 +42,7 @@ function ChooserWidget(id, opts) {
 }
 
 ChooserWidget.prototype.getModalURL = function() {
-    return this.chooserElement.data('choose-modal-url');
+    return this.baseModalURL;
 };
 
 ChooserWidget.prototype.openModal = function() {
@@ -99,4 +100,16 @@ ChooserWidgetFactory.prototype.render = function(placeholder, name, id, initialS
     chooser.setState(initialState);
     return chooser;
 };
+ChooserWidgetFactory.prototype.openModal = function(callback, urlParams) {
+    var responses = [];
+    responses[this.opts.modalWorkflowResponseName || 'chosen'] = callback;
+
+    ModalWorkflow({
+        url: this.opts.modalURL,
+        urlParams: urlParams,
+        onload: GENERIC_CHOOSER_MODAL_ONLOAD_HANDLERS,
+        responses: responses
+    });
+};
+
 window.WagtailGenericChooserWidgetFactory = ChooserWidgetFactory;

--- a/generic_chooser/static/generic_chooser/js/chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget.js
@@ -86,14 +86,15 @@ ChooserWidget.prototype.focus = function() {
 }
 
 
-function ChooserWidgetFactory(html) {
+function ChooserWidgetFactory(html, opts) {
     this.html = html;
+    this.opts = opts;
 }
 ChooserWidgetFactory.prototype.render = function(placeholder, name, id, initialState) {
     var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
     placeholder.outerHTML = html;
 
-    var chooser = new ChooserWidget(id);
+    var chooser = new ChooserWidget(id, this.opts);
     chooser.setState(initialState);
     return chooser;
 };

--- a/generic_chooser/static/generic_chooser/js/chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget.js
@@ -24,12 +24,7 @@ function ChooserWidget(id, opts) {
 
     this.modalResponses = {};
     this.modalResponses[opts.modalWorkflowResponseName || 'chosen'] = function(data) {
-        self.setState({
-            'value': data.id,
-            'title': data.string,
-            'edit_item_url': data.edit_link
-        });
-        self.inputElement.trigger('change');
+        self.setStateFromModalData(data);
     };
 
     this.chooseButton.on('click', function() {
@@ -39,6 +34,9 @@ function ChooserWidget(id, opts) {
     $('.action-clear', this.chooserElement).on('click', function() {
         self.setState(null);
     });
+
+    // attach a reference to this widget object onto the root element of the chooser
+    this.chooserElement.get(0).widget = this;
 }
 
 ChooserWidget.prototype.getModalURL = function() {
@@ -52,6 +50,14 @@ ChooserWidget.prototype.openModal = function() {
         responses: this.modalResponses
     });
 };
+
+ChooserWidget.prototype.setStateFromModalData = function(data) {
+    this.setState({
+        'value': data.id,
+        'title': data.string,
+        'edit_item_url': data.edit_link
+    });
+}
 
 ChooserWidget.prototype.setState = function(newState) {
     if (newState && newState.value !== null && newState.value !== '') {
@@ -68,6 +74,7 @@ ChooserWidget.prototype.setState = function(newState) {
         this.inputElement.val('');
         this.chooserElement.addClass('blank');
     }
+    this.inputElement.trigger('change');
 };
 
 ChooserWidget.prototype.getState = function() {
@@ -111,5 +118,9 @@ ChooserWidgetFactory.prototype.openModal = function(callback, urlParams) {
         responses: responses
     });
 };
+ChooserWidgetFactory.prototype.getById = function(id) {
+    /* retrieve the widget object corresponding to the given HTML ID */
+    return document.getElementById(id + '-chooser').widget;
+}
 
 window.WagtailGenericChooserWidgetFactory = ChooserWidgetFactory;

--- a/generic_chooser/static/generic_chooser/js/chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget.js
@@ -11,7 +11,7 @@ function ChooserWidget(id, opts) {
 
     this.id = id;
     this.chooserElement = $('#' + id + '-chooser');
-    this.titleElement = this.chooserElement.find('.title');
+    this.titleElement = this.chooserElement.find('[data-chooser-title]');
     this.inputElement = $('#' + id);
     this.editLinkElement = this.chooserElement.find('.edit-link');
     this.editLinkWrapper = this.chooserElement.find('.edit-link-wrapper');

--- a/generic_chooser/static/generic_chooser/js/chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget.js
@@ -89,12 +89,13 @@ ChooserWidget.prototype.focus = function() {
 function ChooserWidgetFactory(html, opts) {
     this.html = html;
     this.opts = opts;
+    this.widgetClass = ChooserWidget;
 }
 ChooserWidgetFactory.prototype.render = function(placeholder, name, id, initialState) {
     var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
     placeholder.outerHTML = html;
 
-    var chooser = new ChooserWidget(id, this.opts);
+    var chooser = new this.widgetClass(id, this.opts);
     chooser.setState(initialState);
     return chooser;
 };

--- a/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget-telepath.js
+++ b/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget-telepath.js
@@ -1,16 +1,3 @@
 (function() {
-    function LinkedFieldChooser(html, opts) {
-        this.html = html;
-        this.opts = opts;
-    }
-    LinkedFieldChooser.prototype.render = function(placeholder, name, id, initialState) {
-        var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
-        placeholder.outerHTML = html;
-
-        var chooser = new LinkedFieldChooserWidget(id, this.opts);
-        chooser.setState(initialState);
-        return chooser;
-    };
-
-    window.telepath.register('wagtail_generic_chooser.widgets.LinkedFieldChooser', LinkedFieldChooser);
+    window.telepath.register('wagtail_generic_chooser.widgets.LinkedFieldChooser', window.LinkedFieldChooserWidgetFactory);
 })();

--- a/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget.js
@@ -56,3 +56,19 @@ LinkedFieldChooserWidget.prototype.getModalURL = function() {
     }
     return url;
 }
+
+
+function LinkedFieldChooserWidgetFactory(html, opts) {
+    this.html = html;
+    this.opts = opts;
+}
+LinkedFieldChooserWidgetFactory.prototype.render = function(placeholder, name, id, initialState) {
+    var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
+    placeholder.outerHTML = html;
+
+    var chooser = new LinkedFieldChooserWidget(id, this.opts);
+    chooser.setState(initialState);
+    return chooser;
+};
+
+window.LinkedFieldChooserWidgetFactory = LinkedFieldChooserWidgetFactory;

--- a/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget.js
@@ -61,14 +61,8 @@ LinkedFieldChooserWidget.prototype.getModalURL = function() {
 function LinkedFieldChooserWidgetFactory(html, opts) {
     this.html = html;
     this.opts = opts;
+    this.widgetClass = LinkedFieldChooserWidget;
 }
-LinkedFieldChooserWidgetFactory.prototype.render = function(placeholder, name, id, initialState) {
-    var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
-    placeholder.outerHTML = html;
-
-    var chooser = new LinkedFieldChooserWidget(id, this.opts);
-    chooser.setState(initialState);
-    return chooser;
-};
+LinkedFieldChooserWidgetFactory.prototype = Object.create(ChooserWidgetFactory.prototype);
 
 window.LinkedFieldChooserWidgetFactory = LinkedFieldChooserWidgetFactory;

--- a/generic_chooser/templates/generic_chooser/_listing_tab.html
+++ b/generic_chooser/templates/generic_chooser/_listing_tab.html
@@ -11,6 +11,15 @@
     </form>
 {% endif %}
 
-<div id="search-results" class="listing">
-    {% include results_template %}
-</div>
+{% if is_multiple_choice %}
+    <form action="{{ chosen_multiple_url }}" method="GET" data-multiple-choice-form>
+        <div id="search-results" class="listing">
+            {% include results_template %}
+        </div>
+        <input type="submit" value="{% trans 'Confirm selection' %}" class="button" />
+    </form>
+{% else %}
+    <div id="search-results" class="listing">
+        {% include results_template %}
+    </div>
+{% endif %}

--- a/generic_chooser/templates/generic_chooser/_results.html
+++ b/generic_chooser/templates/generic_chooser/_results.html
@@ -1,17 +1,25 @@
 {% load i18n %}
 
 <table class="listing">
-    <col />
-    <col />
-    <col width="16%" />
+    {% if is_multiple_choice %}
+        <col width="1%">
+    {% endif %}
     <thead>
         <tr class="table-headers">
+            {% if is_multiple_choice %}
+                <th>{% trans "Select" %}</th>
+            {% endif %}
             <th>{% trans "Title" %}</th>
         </tr>
     </thead>
     <tbody>
         {% for row in rows %}
             <tr>
+                {% if is_multiple_choice %}
+                    <td>
+                        <input type="checkbox" name="id" value="{{ row.object_id }}" title="{% blocktrans trimmed with title=row.title %}Select {{ title }}{% endblocktrans %}">
+                    </td>
+                {% endif %}
                 <td class="title">
                     <h2><a class="item-choice" href="{{ row.choose_url }}">{{ row.title }}</a></h2>
                 </td>

--- a/generic_chooser/templates/generic_chooser/widgets/chooser.html
+++ b/generic_chooser/templates/generic_chooser/widgets/chooser.html
@@ -10,7 +10,7 @@
 
     <div class="chosen">
         {% block chosen_state_view %}
-            <span class="title">{{ title }}</span>
+            <span class="title" data-chooser-title>{{ title }}</span>
         {% endblock %}
 
         <ul class="actions">

--- a/generic_chooser/templates/generic_chooser/widgets/chooser_v4.html
+++ b/generic_chooser/templates/generic_chooser/widgets/chooser_v4.html
@@ -17,7 +17,7 @@
             </div>
         {% endblock chosen_icon %}
         {% block chosen_state_view %}
-            <div class="chooser__title">{{ title }}</div>
+            <div class="chooser__title" data-chooser-title>{{ title }}</div>
         {% endblock %}
 
         <ul class="chooser__actions">

--- a/generic_chooser/widgets.py
+++ b/generic_chooser/widgets.py
@@ -204,6 +204,7 @@ class AdminChooserAdapter(WidgetAdapter):
 
     class Media:
         js = [
+            "generic_chooser/js/chooser-widget.js",
             "generic_chooser/js/chooser-widget-telepath.js",
         ]
 
@@ -281,6 +282,7 @@ class LinkedFieldChooserAdapter(WidgetAdapter):
 
     class Media:
         js = [
+            "generic_chooser/js/linked-field-chooser-widget.js",
             "generic_chooser/js/linked-field-chooser-widget-telepath.js",
         ]
 

--- a/generic_chooser/widgets.py
+++ b/generic_chooser/widgets.py
@@ -164,7 +164,9 @@ class AdminChooser(WidgetWithScript, widgets.Input):
         })
 
     def js_opts(self):
-        return {}
+        return {
+            'modalURL': self.get_choose_modal_url(),
+        }
 
     def render_js_init(self, id_, name, value):
         opts = self.js_opts()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -603,6 +603,6 @@ class TestChooserWidget(TestCase):
         form = SiteForm(initial={'site': localhost})
         html = form.as_p()
         if WAGTAIL_VERSION >= (4, 0):
-            self.assertIn('<div class="chooser__title">localhost [default]</div>', html)
+            self.assertIn('<div class="chooser__title" data-chooser-title>localhost [default]</div>', html)
         else:
-            self.assertIn('<span class="title">localhost [default]</span>', html)
+            self.assertIn('<span class="title" data-chooser-title>localhost [default]</span>', html)


### PR DESCRIPTION
Supporting code for multiple chooser panels (https://github.com/wagtail/wagtail/issues/2203#issuecomment-1330952300):

* Add a multiple choice mode to the chooser modal, activated when the `multiple=true` URL parameter is passed, that returns a list of items rather than a single one
* Add an `openModal` method to the telepath ChooserFactory that opens the modal with the specified URL parameters
* Add a `getById` method to the telepath ChooserFactory that allows retrieving the existing JS chooser widget object from the element ID (previously this was only accessible as the return value from `render`, for widgets created through the factory itself)