### PR TITLE
Pass linked-field URL params to openModal

### DIFF
--- a/generic_chooser/static/generic_chooser/js/chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/chooser-widget.js
@@ -43,9 +43,14 @@ ChooserWidget.prototype.getModalURL = function() {
     return this.baseModalURL;
 };
 
+ChooserWidget.prototype.getModalURLParams = function() {
+    return {};
+};
+
 ChooserWidget.prototype.openModal = function() {
     ModalWorkflow({
         url: this.getModalURL(),
+        urlParams: this.getModalURLParams(),
         onload: GENERIC_CHOOSER_MODAL_ONLOAD_HANDLERS,
         responses: this.modalResponses
     });
@@ -107,13 +112,23 @@ ChooserWidgetFactory.prototype.render = function(placeholder, name, id, initialS
     chooser.setState(initialState);
     return chooser;
 };
+ChooserWidgetFactory.prototype.getModalURLParams = function() {
+    return {};
+};
 ChooserWidgetFactory.prototype.openModal = function(callback, urlParams) {
     var responses = [];
     responses[this.opts.modalWorkflowResponseName || 'chosen'] = callback;
 
+    var fullURLParams = this.getModalURLParams();
+    if (urlParams) {
+        for (key in urlParams) {
+            fullURLParams[key] = urlParams[key];
+        }
+    }
+
     ModalWorkflow({
         url: this.opts.modalURL,
-        urlParams: urlParams,
+        urlParams: fullURLParams,
         onload: GENERIC_CHOOSER_MODAL_ONLOAD_HANDLERS,
         responses: responses
     });

--- a/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget.js
+++ b/generic_chooser/static/generic_chooser/js/linked-field-chooser-widget.js
@@ -20,14 +20,10 @@ function LinkedFieldChooserWidget(id, opts) {
     this.linkedFields = opts.linkedFields || {};
 }
 
-LinkedFieldChooserWidget.prototype = Object.create(ChooserWidget.prototype);
-
-LinkedFieldChooserWidget.prototype.getModalURL = function() {
-    var url = ChooserWidget.prototype.getModalURL.call(this);
-
-    queryParams = [];
-    for (var param in this.linkedFields) {
-        var lookup = this.linkedFields[param];
+function getLinkedFieldQueryParams(linkedFields, chooserId) {
+    var queryParams = {};
+    for (var param in linkedFields) {
+        var lookup = linkedFields[param];
         var val;
         if (typeof(lookup) == 'string') {
             val = $(document).find(lookup).val();
@@ -35,8 +31,8 @@ LinkedFieldChooserWidget.prototype.getModalURL = function() {
             val = $(document).find('#' + lookup.id).val();
         } else if (lookup.selector) {
             val = $(document).find(lookup.selector).val();
-        } else if (lookup.match) {
-            var match = this.id.match(new RegExp(lookup.match));
+        } else if (lookup.match && chooserId) {
+            var match = chooserId.match(new RegExp(lookup.match));
             if (match) {
                 var id = match[0];
                 if (lookup.append) {
@@ -46,15 +42,16 @@ LinkedFieldChooserWidget.prototype.getModalURL = function() {
             }
         }
         if (val) {
-            queryParams.push({'name': param, 'value': val});
+            queryParams[param] = val;
         }
     }
-    if (url.indexOf('?') == -1) {
-        url += '?' + $.param(queryParams);
-    } else {
-        url += '&' + $.param(queryParams);
-    }
-    return url;
+    return queryParams;
+}
+
+LinkedFieldChooserWidget.prototype = Object.create(ChooserWidget.prototype);
+
+LinkedFieldChooserWidget.prototype.getModalURLParams = function() {
+    return getLinkedFieldQueryParams(this.linkedFields, this.id);
 }
 
 
@@ -64,5 +61,12 @@ function LinkedFieldChooserWidgetFactory(html, opts) {
     this.widgetClass = LinkedFieldChooserWidget;
 }
 LinkedFieldChooserWidgetFactory.prototype = Object.create(ChooserWidgetFactory.prototype);
+LinkedFieldChooserWidgetFactory.prototype.getModalURLParams = function() {
+    if (this.opts.linkedFields) {
+        return getLinkedFieldQueryParams(this.opts.linkedFields);
+    } else {
+        return {};
+    }
+};
 
 window.LinkedFieldChooserWidgetFactory = LinkedFieldChooserWidgetFactory;


### PR DESCRIPTION
The ChooserWidgetFactory.openModal function (as introduced in #64 and used by https://github.com/wagtail/wagtail-multiple-chooser-panel/) did not work in conjunction with LinkedFieldMixin, because the logic for gathering linked field data into URL params was only in place for the widget's openModal method, not the factory's. Refactor it to be available on both.