### PR TITLE
Fix tests to account for search indexing happening as a background task

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -100,9 +100,10 @@ class TestChooseView(TestCase):
         )
 
         homepage = Page.objects.get(depth=2)
-        red_page = homepage.add_child(title='A red page')
-        another_red_page = homepage.add_child(title='Another red page')
-        green_page = homepage.add_child(title='A green page')
+        with self.captureOnCommitCallbacks(execute=True):
+            red_page = homepage.add_child(title='A red page')
+            another_red_page = homepage.add_child(title='Another red page')
+            green_page = homepage.add_child(title='A green page')
 
         response = self.client.get('/admin/page-chooser/')
         self.assertEqual(response.status_code, 200)
@@ -420,9 +421,10 @@ class TestAPIChooseView(FakeRequestsTestCase):
 
     def test_search(self):
         homepage = Page.objects.get(depth=2)
-        red_page = homepage.add_child(title='A red page')
-        another_red_page = homepage.add_child(title='Another red page')
-        green_page = homepage.add_child(title='A green page')
+        with self.captureOnCommitCallbacks(execute=True):
+            red_page = homepage.add_child(title='A red page')
+            another_red_page = homepage.add_child(title='Another red page')
+            green_page = homepage.add_child(title='A green page')
 
         response = self.client.get('/admin/api-page-chooser/')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
As of https://github.com/wagtail/wagtail/pull/12787 in Wagtail 6.4, search indexing ordinarily happens at the end of the transaction where the objects are created/updated. Since tests are wrapped in transactions, we need to explicitly invoke the oncommit callbacks via `self.captureOnCommitCallbacks(execute=True)` to ensure that the changes we make to the database are reflected in search results.