### PR TITLE
Update license field to use proper SPDX identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'requests>=2.11.1,<3.0',
     ],
-    license='BSD',
+    license='BSD-3-Clause',
     long_description="""
         Base classes for building chooser popups and form widgets for the Wagtail admin,
         matching Wagtail's built-in choosers and backed by either models or a REST API


### PR DESCRIPTION
This changes the license field from 'BSD' to 'BSD-3-Clause' to be a valid [SPDX identifier](https://spdx.org/licenses) aligning with [PEP 639](https://peps.python.org/pep-0639/#project-source-metadata). This populates the `license_expression` field in the PyPI API and is used by downstream tools including deps.dev

This PR was generated by Claude after reviewing the license and manifest files in your repository, but opened and reviewed by me. Please let me know if the analysis is incorrect and thanks for being an OSS maintainer.